### PR TITLE
Add basic CI/CD pipeline for merge requests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,51 @@
+name: Validate
+# Lints, builds, and tests the project whenever a pull request is opened
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  front-end:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./front-end
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Tests
+        run: npm test
+      
+  back-end:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      # Add more steps here later

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "github.vscode-github-actions"
+    ]
+}


### PR DESCRIPTION
Using GitHub Actions, we can have certain steps (like building, testing, etc) run automatically on our code whenever we submit a merge request. This is generally good practice for repositories with lots of collaborators. It's good to double check that everything works before merging to main.

In fact, in the repository settings, you can set it so MRs cannot be merged unless the pipeline succeeds, so MRs that add code that fails to build or doesn't pass testing cannot be merged until they are fixed.

I split the pipeline into two jobs - one for validating the front-end, and one for validating the back-end. If you have test code you use for the back-end, you can add it to the pipeline.

See the pipeline status below - the back-end passes, but the front-end failed (because #20 has not been merged yet, so there is no front-end). Isn't that neat?

I'm happy to explain how any part of this works.